### PR TITLE
Bug? uniqueKeys with type of Long is found as fields changed in SaveResult when they are not

### DIFF
--- a/src/main/java/org/fluentjdbc/DatabaseStatement.java
+++ b/src/main/java/org/fluentjdbc/DatabaseStatement.java
@@ -208,7 +208,9 @@ public class DatabaseStatement {
             dbValue = row.getTimestamp(field);
         } else if (canonicalValue instanceof Integer) {
             dbValue = row.getInt(field);
-        } else {
+        } else if (canonicalValue instanceof Long) {
+            dbValue = row.getLong(field);
+        }else {
             dbValue = row.getObject(field);
         }
         return Objects.equals(canonicalValue, toDatabaseType(dbValue, connection));


### PR DESCRIPTION
`org.fluentjdbc.DatabaseStatement#dbValuesAreEqual`

@jhannes Found some odd behavior while hacking on some code, and found it weird that `shouldInsertThenNoChanged` test fails. 

Sorry for the really bad naming etc, throwns together in a hurry but I think you get the idea. 

Do you agree with it being a bug? It should return with UNCHANGED right?